### PR TITLE
日本語版チュートリアルのURL追加、日本語版DiscordのURL追加

### DIFF
--- a/documentation/docs/10-getting-started/10-introduction.md
+++ b/documentation/docs/10-getting-started/10-introduction.md
@@ -4,9 +4,12 @@ title: イントロダクション
 
 ## 始める前に
 
-> Svelte や SvelteKit が初めてなら、この[インタラクティブなチュートリアル](https://learn.svelte.dev)をチェックしてみることをおすすめします(このインタラクティブなチュートリアルはまだexperimentalです)。
+> Svelte や SvelteKit が初めてなら、この[インタラクティブなチュートリアル](https://learn.svelte.jp)をチェックしてみることをおすすめします(このインタラクティブなチュートリアルはまだexperimentalです)。
 >
 > 行き詰まったら、[Discord chatroom](https://svelte.dev/chat) でヘルプを求めてください。
+
+> 日本語翻訳版 追記：上記のDiscordはSvelte本体のもので、英語でコミュニケーションが行われています。もし日本語で質問したり交流したいのであれば、[Svelte日本のDiscord](https://discord.com/invite/YTXq3ZtBbx)にどうぞ！
+
 
 ## SvelteKitとは
 


### PR DESCRIPTION
- 日本語版チュートリアルのURL追加
- Discordにて、kitのドキュメントにも日本語版Discordへの案内があったほうが良いとアドバイス頂いたので追加
  https://discord.com/channels/777141291800723468/806400012136611880/1054675982084222976